### PR TITLE
setup: ensure utf-8 encoding when reading README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
setup.py reads README.md in prep for build, and README.md is
utf-8 encoded.

Specify the encoding when opening the file to avoid build
failures in environments where the default locale isn't utf-8.
For example, some container environments may default to
non-UTF-8, ASCII-based encodings like 'ANSI_X3.4-1968'.