### PR TITLE
Encode with EOS: change function call

### DIFF
--- a/bpemb/bpemb.py
+++ b/bpemb/bpemb.py
@@ -287,7 +287,7 @@ class BPEmb():
         -------
             The byte-pair-encoded text.
         """
-        return self.encode(
+        return self._encode(
             texts,
             lambda t: self.spm.EncodeAsPieces(t) + [self.EOS_str])
 


### PR DESCRIPTION
It looks like an underscore is missing in the `encode_with_eos` function. Works fine after adding.