### PR TITLE
util: make content header check more robust

### DIFF
--- a/bpemb/util.py
+++ b/bpemb/util.py
@@ -51,7 +51,8 @@ def http_get(url: str, outfile: Path, ignore_tardir=False) -> None:
         # shutil.copyfileobj() starts at current position, so go to the start
         temp_file.seek(0)
         outfile.parent.mkdir(exist_ok=True, parents=True)
-        if headers.get("Content-Type") == "application/x-gzip":
+        content_header = headers.get("Content-Type")
+        if content_header and "gzip" in content_header:
             import tarfile
             tf = tarfile.open(fileobj=temp_file)
             members = tf.getmembers()


### PR DESCRIPTION
Hi,

as investigated in ##66 the `Content-Type` header changed from `application/x-gzip` to `application/x-gzip` for the provided models, such as ` https://nlp.h-its.org/bpemb/en/en.wiki.bpe.vs10000.d100.w2v.bin.tar.gz`.

This MR robustify the download logic a bit and generally checks for `gzip` strin in the `Content-Type` header .